### PR TITLE
Fix product metadata updates triggering woocommerce_product_update ho…

### DIFF
--- a/woocommerce-koban-sync/src/includes/hooks/class-productupdatehook.php
+++ b/woocommerce-koban-sync/src/includes/hooks/class-productupdatehook.php
@@ -90,6 +90,7 @@ class ProductUpdateHook {
 	 * @param int    $attempt The current retry number, 0 if initial attempt.
 	 */
 	public function handle_product_update( int $product_id, string $workflow_id, int $attempt ): void {
+		remove_action( 'woocommerce_update_product', array( $this, 'schedule_product_update' ) );
 		Logger::debug(
 			$workflow_id,
 			'Detected product create/update',
@@ -111,6 +112,7 @@ class ProductUpdateHook {
 		$this->api   = new API( $workflow_id );
 		$state->process_steps();
 		$this->handle_exit( $state, $attempt );
+		add_action( 'woocommerce_update_product', array( $this, 'schedule_product_update' ) );
 	}
 
 	/**


### PR DESCRIPTION
removing the hook at the begining of handle_product_update and re-adding it at the end