### PR TITLE
Fix Customer Save Address Hook

### DIFF
--- a/woocommerce-koban-sync/src/includes/serializers/class-thirdserializer.php
+++ b/woocommerce-koban-sync/src/includes/serializers/class-thirdserializer.php
@@ -9,9 +9,8 @@
 
 namespace WCKoban\Serializers;
 
+use WC_Customer;
 use WC_Order;
-use WP_User;
-use WCKoban\Logger;
 
 /**
  * Class ThirdSerializer
@@ -34,13 +33,13 @@ class ThirdSerializer {
 	}
 
 	/**
-	 *  WP_User to Koban Third payload
+	 *  WC_Customer to Koban Third payload
 	 *
-	 * @param WP_User $user The WordPress User.
+	 * @param WC_Customer $user The WooCommerce Customer.
 	 *
 	 * @return array The Koban Third payload.
 	 */
-	public function from_user( WP_User $user ): array {
+	public function from_user( WC_Customer $user ): array {
 		return $this->billing_to_koban_third(
 			$this->billing_data_from_user( $user )
 		);
@@ -62,7 +61,6 @@ class ThirdSerializer {
 			'address_1'  => '',
 			'address_2'  => '',
 			'city'       => '',
-			'state'      => '',
 			'postcode'   => '',
 			'country'    => '',
 		);
@@ -77,40 +75,43 @@ class ThirdSerializer {
 		$status_code = CUSTOMER_THIRD_STATUS_CODE;
 		$type_code   = CUSTOMER_COUNTRY_THIRD_TYPE_CODE_MAPPER[ $billing['country'] ] ?? 'Particuliers (Autre)';
 
+		$billing_address = array(
+			'Name'      => $billing['last_name'],
+			'FirstName' => $billing['first_name'],
+			'Phone'     => $billing['phone'],
+			'Street'    => trim( $billing['address_1'] . ' ' . $billing['address_2'] ),
+			'ZipCode'   => $billing['postcode'],
+			'City'      => $billing['city'],
+			'Country'   => $billing['country'] ? mb_strtoupper( $billing['country'], 'utf-8' ) : 'FR',
+		);
+
 		return array(
-			'Label'      => $label,
-			'FirstName'  => $billing['first_name'],
-			'Status'     => array(
+			'Label'          => $label,
+			'FirstName'      => $billing['first_name'],
+			'Status'         => array(
 				'Code' => $status_code,
 			),
-			'Type'       => array(
+			'Type'           => array(
 				'Code' => $type_code,
 			),
-			'Address'    => array(
-				'Name'      => $billing['last_name'],
-				'FirstName' => $billing['first_name'],
-				'Phone'     => $billing['phone'],
-				'Street'    => trim( $billing['address_1'] . ' ' . $billing['address_2'] ),
-				'ZipCode'   => $billing['postcode'],
-				'City'      => $billing['city'],
-				'Country'   => $billing['country'] ? mb_strtoupper( $billing['country'], 'utf-8' ) : 'FR',
-			),
-			'EMail'      => $billing['email'],
-			'AssignedTo' => array(
+			'Address'        => $billing_address,
+			'InvoiceAddress' => $billing_address,
+			'EMail'          => $billing['email'],
+			'AssignedTo'     => array(
 				'FullName' => DEFAULT_ASSIGNEDTO_FULLNAME,
 			),
-			'Optin'      => true,
+			'Optin'          => true,
 		);
 	}
 
 	/**
 	 * Extracts relevant billing fields from a WordPress User.
 	 *
-	 * @param WP_User $user The WordPress user object.
+	 * @param WC_Customer $user The WooCommerce Customer.
 	 *
 	 * @return array An associative array of billing data.
 	 */
-	protected static function billing_data_from_user( WP_User $user ): array {
+	protected static function billing_data_from_user( WC_Customer $user ): array {
 		return array(
 			'first_name' => $user->get_billing_first_name(),
 			'last_name'  => $user->get_billing_last_name(),
@@ -119,7 +120,6 @@ class ThirdSerializer {
 			'address_1'  => $user->get_billing_address_1(),
 			'address_2'  => $user->get_billing_address_2(),
 			'city'       => $user->get_billing_city(),
-			'state'      => $user->get_billing_state(),
 			'postcode'   => $user->get_billing_postcode(),
 			'country'    => $user->get_billing_country(),
 		);
@@ -141,7 +141,6 @@ class ThirdSerializer {
 			'address_1'  => $order->get_billing_address_1(),
 			'address_2'  => $order->get_billing_address_2(),
 			'city'       => $order->get_billing_city(),
-			'state'      => $order->get_billing_state(),
 			'postcode'   => $order->get_billing_postcode(),
 			'country'    => $order->get_billing_country(),
 		);

--- a/woocommerce-koban-sync/tests/hooks/test-customersaveaddresshook.php
+++ b/woocommerce-koban-sync/tests/hooks/test-customersaveaddresshook.php
@@ -81,7 +81,7 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 	/**
 	 * Customer with Koban GUID billing address modification
 	 */
-	public function test_customer_save_address_billing_with_guid() {
+	public function test_customer_save_address_with_guid() {
 		$customer_id = $this->customer_with_guid_id;
 
 		$expected_requests = array(
@@ -91,7 +91,6 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 
 		( new CustomerSaveAddressHook() )->handle_customer_save_address(
 			$customer_id,
-			'billing',
 			'workflow_id',
 			0
 		);
@@ -103,10 +102,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 			as_next_scheduled_action(
 				'wckoban_handle_customer_save_address',
 				array(
-					'customer_id'  => $this->customer_with_guid_id,
-					'address_type' => 'billing',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 1,
+					'customer_id' => $this->customer_with_guid_id,
+					'workflow_id' => 'workflow_id',
+					'attempt'     => 1,
 				),
 				'koban-sync'
 			),
@@ -117,10 +115,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 	/**
 	 * Customer without Koban GUID billing address modification
 	 */
-	public function test_customer_save_address_billing_no_guid() {
+	public function test_customer_save_addressg_no_guid() {
 		( new CustomerSaveAddressHook() )->handle_customer_save_address(
 			$this->customer_without_guid_id,
-			'billing',
 			'workflow_id',
 			0
 		);
@@ -142,49 +139,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 			as_next_scheduled_action(
 				'wckoban_handle_customer_save_address',
 				array(
-					'customer_id'  => $this->customer_with_guid_id,
-					'address_type' => 'billing',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 1,
-				),
-				'koban-sync'
-			),
-			'Expected no scheduling after stop.'
-		);
-	}
-
-	/**
-	 * Customer with Koban GUID shipping address modification
-	 */
-	public function test_customer_save_address_shipping_with_guid() {
-		( new CustomerSaveAddressHook() )->handle_customer_save_address(
-			$this->customer_with_guid_id,
-			'shipping',
-			'workflow_id',
-			0
-		);
-
-		$this->assertRequestsCount( 0 );
-
-		$this->assertSame(
-			StateMachine::STATUS_STOP,
-			MetaUtils::get_koban_workflow_status_for_user_id( $this->customer_with_guid_id ),
-			'Expected the workflow to stop with shipping address.'
-		);
-
-		$this->assertEmpty(
-			MetaUtils::get_koban_workflow_failed_step_for_user_id( $this->customer_with_guid_id ),
-			'Expected failed_step to be cleared if not retrying.'
-		);
-
-		$this->assertFalse(
-			as_next_scheduled_action(
-				'wckoban_handle_customer_save_address',
-				array(
-					'customer_id'  => $this->customer_with_guid_id,
-					'address_type' => 'shipping',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 1,
+					'customer_id' => $this->customer_with_guid_id,
+					'workflow_id' => 'workflow_id',
+					'attempt'     => 1,
 				),
 				'koban-sync'
 			),
@@ -198,7 +155,6 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 	public function test_customer_save_address_check_data_integrity_fails_no_retries() {
 		( new CustomerSaveAddressHook() )->handle_customer_save_address(
 			123,
-			'billing',
 			'workflow_id',
 			0
 		);
@@ -208,10 +164,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 			as_next_scheduled_action(
 				'wckoban_customer_save_address',
 				array(
-					'customer_id'  => 123,
-					'address_type' => 'billing',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 1,
+					'customer_id' => 123,
+					'workflow_id' => 'workflow_id',
+					'attempt'     => 1,
 				),
 				'koban-sync'
 			),
@@ -234,7 +189,6 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 		$hook::$max_retries = 1;
 		$hook->handle_customer_save_address(
 			$this->customer_with_guid_id,
-			'billing',
 			'workflow_id',
 			0
 		);
@@ -255,10 +209,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 			as_next_scheduled_action(
 				'wckoban_handle_customer_save_address',
 				array(
-					'customer_id'  => $this->customer_with_guid_id,
-					'address_type' => 'billing',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 1,
+					'customer_id' => $this->customer_with_guid_id,
+					'workflow_id' => 'workflow_id',
+					'attempt'     => 1,
 				),
 				'koban-sync'
 			),
@@ -276,7 +229,6 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 		$hook::$max_retries = 1;
 		$hook->handle_customer_save_address(
 			$this->customer_with_guid_id,
-			'billing',
 			'workflow_id',
 			1
 		);
@@ -296,10 +248,9 @@ class TestCustomerSaveAddressHook extends WCKoban_UnitTestCase {
 			as_next_scheduled_action(
 				'wckoban_handle_customer_save_address',
 				array(
-					'customer_id'  => $this->customer_with_guid_id,
-					'address_type' => 'billing',
-					'workflow_id'  => 'workflow_id',
-					'attempt'      => 2,
+					'customer_id' => $this->customer_with_guid_id,
+					'workflow_id' => 'workflow_id',
+					'attempt'     => 2,
 				),
 				'koban-sync'
 			),


### PR DESCRIPTION
retrieve billing data from WC_Customer instead of WP_User
removed unnecessary state field
removed unnecessary address_type